### PR TITLE
Correct UUID that stops code working

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
- "uuid": "cinnamon-multi-line-taskbar-applet",
+ "uuid": "cinnamon-multi-line-taskbar-applet-master",
  "name": "Cinnamon Multi-Line Taskbar",
  "description": "https://github.com/posto/cinnamon-multi-line-taskbar-applet",
  "icon": "gnome-panel-window-list"


### PR DESCRIPTION
Hi,
   I have got this applet working, but it did not work when I first installed it I got an error about a miss matched UUID. I copied the folder name from the install into the UUID field of the json file. It is now working on my systems.

Regards
   Jon
