### PR TITLE
optionally include windows from all workspaces. fixes #4

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -21,6 +21,8 @@ const TASKBAR_ROW_COUNT = 3;
 const MIN_BUTTONS_PER_LINE = 8;
 // shall the taskbar include windows from all workspaces (1) or just from the current workspace (0)?
 const TASKBAR_ALL_WORKSPACES = 1;
+// behavior on clicking the middle mouse button: 0=close window (old style), 1="clone" (Windows-7 style)
+const TASK_MIDDLECLICK_ACTION=1
 
 /* CODE, DO NOT CHANGE ANYTHING BELOW THIS LINE */
 const Applet = imports.ui.applet;
@@ -443,7 +445,11 @@ AppMenuButton.prototype = {
             }
             this._windowHandle(false);
         } else if (Cinnamon.get_event_state(event) & Clutter.ModifierType.BUTTON2_MASK) {
-            this.metaWindow.delete(global.get_current_time());
+            if (TASK_MIDDLECLICK_ACTION == 0) {
+                this.metaWindow.delete(global.get_current_time());
+            } else if (TASK_MIDDLECLICK_ACTION == 1) {
+                this.app.open_new_window(global.get_current_time());
+            }
         } else if (Cinnamon.get_event_state(event) & Clutter.ModifierType.BUTTON3_MASK) {
             this.rightClickMenu.mouseEvent = event;
             this.rightClickMenu.toggle();   

--- a/applet.js
+++ b/applet.js
@@ -19,6 +19,8 @@ global.stage.get_actor_at_pos(Clutter.PickMode.ALL, 427, 1046).get_parent().get_
 const TASKBAR_ROW_COUNT = 3;
 // minimum number of tasks on one line, before we start filling in the next line
 const MIN_BUTTONS_PER_LINE = 8;
+// shall the taskbar include windows from all workspaces (1) or just from the current workspace (0)?
+const TASKBAR_ALL_WORKSPACES = 1;
 
 /* CODE, DO NOT CHANGE ANYTHING BELOW THIS LINE */
 const Applet = imports.ui.applet;
@@ -873,7 +875,8 @@ MyApplet.prototype = {
         for ( let i = 0; i < this._windows.length; ++i ) {
             let metaWindow = this._windows[i].metaWindow;
             if (metaWindow.get_workspace().index() == global.screen.get_active_workspace_index()
-                      || metaWindow.is_on_all_workspaces()) {
+                      || metaWindow.is_on_all_workspaces()
+                      || TASKBAR_ALL_WORKSPACES == 1) {
                 this._addWindowBtnToTaskbar(this._windows[i]);
                 this._windows[i].actor.show();
             } else {
@@ -944,7 +947,7 @@ try {
         let appbutton = new AppMenuButton(this, metaWindow, true,      this.orientation, this._panelHeight);
         this._windows.push(appbutton);
 
-        if (metaWorkspace.index() != global.screen.get_active_workspace_index()) {
+        if (TASKBAR_ALL_WORKSPACES == 0 && metaWorkspace.index() != global.screen.get_active_workspace_index()) {
             appbutton.actor.hide();
         } else {
             // add actor only if it should be shown


### PR DESCRIPTION
Well, solving my own issue here: In the configuration setting, I've introduced a new constant `TASKBAR_ALL_WORKSPACES`. Set it to `1` to include windows from all workspaces with the taskbar (oops, that's what I've pushed right now), or to `0` to only list windows from the current workspace (as it was before my PR).